### PR TITLE
Improve documentation and update broken setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,20 +58,42 @@ goal of being fully self-hosting (i.e. ClojureScript-in-ClojureScript).
 
 ### Build
 
-You can rebuild the ClojureScript analyzer, compiler, reader and
-browser bootstrap pieces with a web REPL like this:
+The ClojureScript-in-ClojureScript compiler is compiled using Clojure (i.e. on the JVM).
+
+First, run `./script/bootstrap` which downloads the necessary dependencies: Clojure, Google Closure Library, Google Closure Compiler, and Rhino. This must be run from the root project directory.
+
+Next, run `./script/compile` to build the compiler. This might give off some warnings, but that's okay.
+
+You should now have a functioning ClojureScript compiler at `./bin/cljs`.
+
+
+### Usage
+
+The `./bin/cljsc` script takes a file or project directory containing .cljs files. It creates an `out` folder with your compiled JavaScript.  It optionally accepts a second argument with Google Closure Compiler options, although it currently won't work with any optimization mode other than `{:optimizations :none}` (the default).
+
+After building a cljs project, you will need to copy `./src/cljs/goog.js` into the `out` directory created by compilation if it doesn't already exist there.
+
+### Examples
+
+#### Web REPL
+There is a sample project (a web-based REPL) you can build and play with inside the `web` directory.
+
+It comes with a build script:
 
 ```
 cd web
-../bin/cljsc ../src/cljs/webrepl.cljs > webrepl.js
+./build2.sh
 ```
-Now load the `web/jsrepl.html` file in a browser.
+
+Now open the `web/repl.html` file in a browser.
+
+#### Node.js REPL
 
 For a REPL in Node.js, build the `src/cljs/noderepl.cljs` code:
 
 ```
 cd node
-../bin/cljsc ../src/cljs/noderepl.cljs > noderepl.js
+../bin/cljsc ../noderepl.cljs > noderepl.js
 cp ../src/cljs/goog.js out/
 ```
 
@@ -81,6 +103,7 @@ Now use the `run.js` bootstrap code to launch the repl:
 ./run.js noderepl.js
 ```
 
+#### Node.js compilation/evaluation
 For direct *.cljs file compilation/evaluation, build the nodecljs.cljs compiler:
 
 ```

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -5,14 +5,14 @@ set -e
 mkdir -p lib
 
 echo "Fetching Clojure..."
-curl -O -s http://repo1.maven.org/maven2/org/clojure/clojure/1.4.0/clojure-1.4.0.zip
-unzip -qu clojure-1.4.0.zip
-echo "Copying clojure-1.4.0/clojure-1.4.0.jar to lib/clojure.jar..."
-cp clojure-1.4.0/clojure-1.4.0.jar lib/clojure.jar
+curl -O -s http://repo1.maven.org/maven2/org/clojure/clojure/1.5.1/clojure-1.5.1.zip
+unzip -qu clojure-1.5.1.zip
+echo "Copying clojure-1.5.1/clojure-1.5.1.jar to lib/clojure.jar..."
+cp clojure-1.5.1/clojure-1.5.1.jar lib/clojure.jar
 echo "Cleaning up Clojure directory..."
-rm -rf clojure-1.4.0/
+rm -rf clojure-1.5.1/
 echo "Cleaning up Clojure archive..."
-rm clojure-1.4.0.zip
+rm clojure-1.5.1.zip
 
 echo "Fetching Google Closure library..."
 mkdir -p closure/library
@@ -34,7 +34,7 @@ if [ "$1" = "--closure-library-head" ] ; then
     fi
 else
     echo "Fetching Google Closure library..."
-    f=closure-library-20111110-r1376.zip
+    f=closure-library-20130212-95c19e7f0f5f.zip
     curl -O -s "http://closure-library.googlecode.com/files/$f"
     unzip -qu "$f"
     echo "Cleaning up Google Closure library archive..."

--- a/src/cljs/cljs/core.cljs
+++ b/src/cljs/cljs/core.cljs
@@ -8609,7 +8609,7 @@ reduces them without incurring seq initialization"
                                 (conj (pop groups) (conj (peek groups) [k v]))
                                 (conj groups [k v])))
                             [] (partition 2 seq-exprs)))
-        err (fn [& msg] (throw (js/Error. (apply core/str msg))))
+        err (fn [& msg] (throw (js/Error. (apply cljs.core/str msg))))
         emit-bind (fn emit-bind [[[bind expr & mod-pairs]
                                   & [[_ next-expr] :as next-groups]]]
                     (let [giter (gensym "iter__")

--- a/src/cljs/cljs/core.cljs
+++ b/src/cljs/cljs/core.cljs
@@ -9,7 +9,6 @@
 (ns cljs.core
   (:require [goog.string :as gstring]
             [goog.string.StringBuffer :as gstringbuf]
-            [goog.string.format]
             [goog.object :as gobject]
             [goog.array :as garray])
   (:use-macros [cljs.core-macros :only [clj-defmacro]]))


### PR DESCRIPTION
I recently tried to get this set up for a project I've been working on, but found it incredibly difficult to get set up because of the lack of documentation.

This pull request contains a slightly-more-helpful README, a few minor tweaks to `core.cljs` that were required to get it to compile, and an update to the `bootstrap` script to use newer versions of Clojure/etc.

(Hat tip to @gideonite, who I paired with on this.)
