### PR TITLE
`com.google.javascript.jscomp.JSSourceFile` depreciation issues

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -45,7 +45,7 @@ cd ..
 echo "Fetching Google Closure compiler..."
 mkdir -p compiler
 cd compiler
-curl -O -s http://closure-compiler.googlecode.com/files/compiler-latest.zip
+curl -O -s http://dl.google.com/closure-compiler/compiler-latest.zip
 unzip -qu compiler-latest.zip
 echo "Cleaning up Google Closure compiler archive..."
 rm compiler-latest.zip

--- a/src/clj/cljs/closure.clj
+++ b/src/clj/cljs/closure.clj
@@ -48,7 +48,7 @@
            com.google.javascript.jscomp.SourceMap$Format
            com.google.javascript.jscomp.SourceMap$DetailLevel
            com.google.javascript.jscomp.ClosureCodingConvention
-           com.google.javascript.jscomp.JSSourceFile
+           com.google.javascript.jscomp.SourceFile
            com.google.javascript.jscomp.Result
            com.google.javascript.jscomp.JSError
            com.google.javascript.jscomp.CommandLineRunner))
@@ -67,13 +67,13 @@
 (defmulti js-source-file (fn [_ source] (class source)))
 
 (defmethod js-source-file String [^String name ^String source]
-  (JSSourceFile/fromCode name source))
+  (SourceFile/fromCode name source))
 
 (defmethod js-source-file File [_ ^File source]
-  (JSSourceFile/fromFile source))
+  (SourceFile/fromFile source))
 
 (defmethod js-source-file BufferedInputStream [^String name ^BufferedInputStream source]
-  (JSSourceFile/fromInputStream name source))
+  (SourceFile/fromInputStream name source))
 
 (defn set-options
   "TODO: Add any other options that we would like to support."


### PR DESCRIPTION
Application of patch `a4f7a89a887c483722f6ec6d75e0e7c76c7d92b2` from clojurescript master to fix `com.google.javascript.jscomp.JSSourceFile` depreciation issues.

This fork of ClojureScript is completely broken without this fix.
