### PR TITLE
Fix to namespace handling of try/catch to accept `js` as namespace.

### DIFF
--- a/src/clj/cljs/analyzer.clj
+++ b/src/clj/cljs/analyzer.clj
@@ -281,7 +281,9 @@
         body (if name (pop body) body)
         try (when body
               (analyze-block (if (or name finally) catchenv env) body))]
-    (when name (assert (not (namespace name)) "Can't qualify symbol in catch"))
+    (when name (assert (not (or (namespace name)
+                                (= (namespace name) "js")))
+                                "Can't qualify symbol in catch"))
     {:env env :op :try* :form form
      :try try
      :finally finally

--- a/src/clj/cljs/analyzer.clj
+++ b/src/clj/cljs/analyzer.clj
@@ -281,8 +281,8 @@
         body (if name (pop body) body)
         try (when body
               (analyze-block (if (or name finally) catchenv env) body))]
-    (when name (assert (not (or (namespace name)
-                                (= (namespace name) "js")))
+    (when name (assert (not (and (namespace name)
+                                (not= (namespace name) "js")))
                                 "Can't qualify symbol in catch"))
     {:env env :op :try* :form form
      :try try

--- a/src/cljs/cljs/analyzer.cljs
+++ b/src/cljs/cljs/analyzer.cljs
@@ -274,7 +274,9 @@
         body (if name (pop body) body)
         try (when body
               (analyze-block (if (or name finally) catchenv env) body))]
-    (when name (assert (not (namespace name)) "Can't qualify symbol in catch"))
+    (when name (assert (not (and (namespace name)
+                                (not= (namespace name) "js")))
+                                "Can't qualify symbol in catch"))
     {:env env :op :try* :form form
      :try try
      :finally finally


### PR DESCRIPTION
Corrects issue #41
