### PR TITLE
CLJS-417

### DIFF
--- a/src/clj/cljs/core.clj
+++ b/src/clj/cljs/core.clj
@@ -290,7 +290,7 @@
   ([x y] (list 'js* "((~{} < ~{}) ? ~{} : ~{})" x y x y))
   ([x y & more] `(min (min ~x ~y) ~@more)))
 
-(defmacro mod [num div]
+(defmacro js-mod [num div]
   (list 'js* "(~{} % ~{})" num div))
 
 (defmacro bit-not [x]

--- a/src/cljs/cljs/core.cljs
+++ b/src/cljs/cljs/core.cljs
@@ -1322,15 +1322,20 @@ reduces them without incurring seq initialization"
   [x]
   (fix x))
 
+(defn js-mod
+  "Modulus of num and div with original javascript behavior. i.e. bug for negative numbers"
+  [n d]
+  (cljs.core/js-mod n d))
+
 (defn mod
   "Modulus of num and div. Truncates toward negative infinity."
   [n d]
-  (cljs.core/mod n d))
+  (js-mod (+ (js-mod n d) d) d))
 
 (defn quot
   "quot[ient] of dividing numerator by denominator."
   [n d]
-  (let [rem (mod n d)]
+  (let [rem (js-mod n d)]
     (fix (/ (- n rem) d))))
 
 (defn rem
@@ -1538,7 +1543,7 @@ reduces them without incurring seq initialization"
   (loop [h 0 s (seq m)]
     (if s
       (let [e (first s)]
-        (recur (mod (+ h (bit-xor (hash (key e)) (hash (val e))))
+        (recur (js-mod (+ h (bit-xor (hash (key e)) (hash (val e))))
                     4503599627370496)
                (next s)))
       h)))
@@ -1548,7 +1553,7 @@ reduces them without incurring seq initialization"
   (loop [h 0 s (seq s)]
     (if s
       (let [e (first s)]
-        (recur (mod (+ h (hash e)) 4503599627370496)
+        (recur (js-mod (+ h (hash e)) 4503599627370496)
                (next s)))
       h)))
 

--- a/test/cljs/cljs/core_test.cljs
+++ b/test/cljs/cljs/core_test.cljs
@@ -156,6 +156,7 @@
   (assert (= (apply mod [4 2]) 0))
   (assert (= (mod 3 2) 1))
   (assert (= (apply mod [3 2]) 1))
+  (assert (= (mod -2 5) 3))
 
   (assert (= [4 3 2 1 0] (loop [i 0 j ()]
                  (if (< i 5)


### PR DESCRIPTION
Applied CLJS-417 from https://github.com/clojure/clojurescript/commit/14bd16ef5894458a3709ebfee3e78a876938bfa6

This corrects the lack of `js-mod` that was causing `core.async` to break.
