### PR TITLE
CLJS-495

### DIFF
--- a/src/clj/cljs/core.clj
+++ b/src/clj/cljs/core.clj
@@ -202,6 +202,9 @@
 (defmacro false? [x]
   (bool-expr (list 'js* "~{} === false" x)))
 
+(defmacro exists? [x]
+  (bool-expr (list 'js* "typeof ~{} !== 'undefined'" x)))
+
 (defmacro undefined? [x]
   (bool-expr (list 'js* "(void 0 === ~{})" x)))
 

--- a/src/cljs/cljs/core.cljs
+++ b/src/cljs/cljs/core.cljs
@@ -1004,6 +1004,10 @@ reduces them without incurring seq initialization"
   "Returns true if x is the value true, false otherwise."
   [x] (cljs.core/true? x))
 
+(defn ^boolean exists?
+  "Return true if object exists, false otherwise."
+  [x] (not= "undefined" (goog/typeOf x)))
+
 (defn ^boolean undefined? [x]
   (cljs.core/undefined? x))
 


### PR DESCRIPTION
Implement CLJS-495 on the clojure version of the compiler by applying https://github.com/clojure/clojurescript/commit/3ee148acac436dd489396fc6783ba72bbd7ff79f -- on the cljs version, it's a `defn` that calls `goog/typeOf`.
